### PR TITLE
Forgot a mount

### DIFF
--- a/install/docker.md
+++ b/install/docker.md
@@ -25,12 +25,14 @@ services:
     volumes:
       - pogly-keys:/etc/spacetimedb
       - pogly-data:/stdb
+      - pogly-config:/root/.spacetime
     # Optional, if you'd like multiple modules you can specify the names here, space seperated
     # environment:
     #   MODULES: "pogly module2 module3"
 volumes:
   pogly-keys:
   pogly-data:
+  pogly-config:
 ```
 
 ## Usage


### PR DESCRIPTION
This one is needed so as to not lose the server identity each time the container is recreated